### PR TITLE
[RTL] Decapsulation implicit rejection flow

### DIFF
--- a/src/abr_top/rtl/abr_ctrl_pkg.sv
+++ b/src/abr_top/rtl/abr_ctrl_pkg.sv
@@ -63,6 +63,7 @@ package abr_ctrl_pkg;
     localparam MLKEM_EK_MEM_NUM_DWORDS = 384;
     localparam MLKEM_DK_MEM_NUM_DWORDS = 768;
     localparam MLKEM_CIPHERTEXT_MEM_NUM_DWORDS = 392;
+    localparam CT_NUM_BYTES = MLKEM_CIPHERTEXT_MEM_NUM_DWORDS*4;
     localparam MLKEM_MSG_MEM_NUM_DWORDS = 8;
     localparam SCRATCH_REG_NUM_DWORDS = 48;
 
@@ -306,6 +307,7 @@ package abr_ctrl_pkg;
     localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_DEST_RHO_SIGMA_REG_ID = 'd9;
     localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_DEST_TR_REG_ID    = 'd10;
     localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_DEST_K_R_REG_ID   = 'd11;
+    localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_DEST_K_REG_ID   = 'd12;
     // DEST Mem overloaded into SK ram
     localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_DEST_DK_MEM_OFFSET = 'd0;
     localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_SRC_DK_MEM_OFFSET = MLKEM_DEST_DK_MEM_OFFSET/2;
@@ -339,6 +341,8 @@ package abr_ctrl_pkg;
     localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_TR_ID          = 'd32;
     localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_MSG_ID         = 'd33;
     localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_R_ID           = 'd34;
+    localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_SEED_Z_ID      = 'd35;
+    localparam [ABR_OPR_WIDTH-1 : 0] MLKEM_CIPHERTEXT_ID  = 'd36;
     
     //SK offsets in dwords
     localparam [ABR_OPR_WIDTH-1 : 0] MLDSA_SK_S1_OFFSET = 'd32;
@@ -557,7 +561,7 @@ package abr_ctrl_pkg;
     localparam [ABR_PROG_ADDR_W-1 : 0] MLKEM_DECAPS_S = MLKEM_KG_E + 1;
     localparam [ABR_PROG_ADDR_W-1 : 0] MLKEM_DECAPS_E = MLKEM_DECAPS_S + 15;
     localparam [ABR_PROG_ADDR_W-1 : 0] MLKEM_ENCAPS_S = MLKEM_DECAPS_E + 1;
-    localparam [ABR_PROG_ADDR_W-1 : 0] MLKEM_ENCAPS_E = MLKEM_ENCAPS_S + 51;
+    localparam [ABR_PROG_ADDR_W-1 : 0] MLKEM_ENCAPS_E = MLKEM_ENCAPS_S + 53;
 
 
 

--- a/src/abr_top/rtl/abr_seq.sv
+++ b/src/abr_top/rtl/abr_seq.sv
@@ -713,6 +713,8 @@ module abr_seq
                 MLKEM_ENCAPS_S + 48: data_o_rom <= '{opcode:ABR_UOP_MLKEM_PWA, imm:'h0000, length:'d00, operand1:MLKEM_V_BASE, operand2:MLKEM_E_2_BASE, operand3:MLKEM_V_BASE};
                 MLKEM_ENCAPS_S + 49: data_o_rom <= '{opcode:ABR_UOP_COMPRESS, imm:'h0402, length:'d04, operand1:MLKEM_U0_BASE, operand2:ABR_NOP, operand3:MLKEM_DEST_C1_MEM_OFFSET};
                 MLKEM_ENCAPS_S + 50: data_o_rom <= '{opcode:ABR_UOP_COMPRESS, imm:'h0101, length:'d00, operand1:MLKEM_V_BASE, operand2:ABR_NOP, operand3:MLKEM_DEST_C2_MEM_OFFSET};
+                MLKEM_ENCAPS_S + 51: data_o_rom <= '{opcode:ABR_UOP_LD_SHAKE256,  imm:'h0000, length:'d32, operand1:MLKEM_SEED_Z_ID, operand2:ABR_NOP, operand3:ABR_NOP};
+                MLKEM_ENCAPS_S + 52: data_o_rom <= '{opcode:ABR_UOP_SHAKE256,  imm:'h0000, length:CT_NUM_BYTES, operand1:MLKEM_CIPHERTEXT_ID, operand2:ABR_NOP, operand3:MLKEM_DEST_K_REG_ID};
                 MLKEM_ENCAPS_E + 0 : data_o_rom <= '{opcode:ABR_UOP_NOP, imm:'h0000, length:'d00, operand1:ABR_NOP, operand2:ABR_NOP, operand3:ABR_NOP};
 
                 default :              data_o_rom <= '{opcode: ABR_UOP_NOP, imm:'h0000, length:'d00, operand1:ABR_NOP, operand2:ABR_NOP, operand3:ABR_NOP};

--- a/src/abr_top/rtl/abr_top.sv
+++ b/src/abr_top/rtl/abr_top.sv
@@ -193,13 +193,16 @@ module abr_top
 
   logic compress_enable;
   logic compress_done;
+  logic compress_compare_failed;
   compress_mode_t compress_mode;
+  logic compress_compare_mode;
   logic [2:0] compress_num_poly;
   mem_if_t compress_mem_rd_req;
   logic [ABR_MEM_DATA_WIDTH-1:0] compress_mem_rd_data;
-  logic compress_api_wr_en;
-  logic [ABR_MEM_ADDR_WIDTH-1:0] compress_api_wr_addr;
+  logic [1:0] compress_api_rw_en;
+  logic [ABR_MEM_ADDR_WIDTH-1:0] compress_api_rw_addr;
   logic [DATA_WIDTH-1:0] compress_api_wr_data;
+  logic [DATA_WIDTH-1:0] compress_api_rd_data;
 
   logic decompress_enable;
   logic decompress_done;
@@ -445,10 +448,13 @@ abr_ctrl abr_ctrl_inst
   .compress_enable_o(compress_enable),
   .compress_mode_o(compress_mode),
   .compress_num_poly_o(compress_num_poly),
+  .compress_compare_mode_o(compress_compare_mode),
   .compress_done_i(compress_done),
-  .compress_api_wr_en_i(compress_api_wr_en),
-  .compress_api_wr_addr_i(compress_api_wr_addr),
+  .compress_compare_failed_i(compress_compare_failed),
+  .compress_api_rw_en_i(compress_api_rw_en),
+  .compress_api_rw_addr_i(compress_api_rw_addr),
   .compress_api_wr_data_i(compress_api_wr_data),
+  .compress_api_rd_data_o(compress_api_rd_data),
 
   .decompress_enable_o(decompress_enable),
   .decompress_mode_o(decompress_mode),
@@ -925,19 +931,22 @@ compress_top_inst
   .zeroize(zeroize_reg),
 
   .mode(compress_mode),
+  .compare_mode(compress_compare_mode),
   .num_poly(compress_num_poly),
   .src_base_addr(aux_src0_base_addr[0]),
   .dest_base_addr(aux_dest_base_addr[0]),
 
   .compress_enable(compress_enable),
   .compress_done(compress_done),
+  .compare_failed(compress_compare_failed),
 
   .mem_rd_req(compress_mem_rd_req),
   .mem_rd_data(compress_mem_rd_data),
 
-  .api_wr_en(compress_api_wr_en),
-  .api_wr_addr(compress_api_wr_addr),
-  .api_wr_data(compress_api_wr_data)
+  .api_rw_en(compress_api_rw_en),
+  .api_rw_addr(compress_api_rw_addr),
+  .api_wr_data(compress_api_wr_data),
+  .api_rd_data(compress_api_rd_data)
 );
 
 decompress_top


### PR DESCRIPTION
use compare functionality to compare decapsulated ciphertext with result of encapsulation flow if ciphertexts do not match, the shared secret is overwritten with a rejection value