### PR TITLE
[DOC] Document mandatory ZEROIZE between operations in MLDSA/MLKEM flows

### DIFF
--- a/docs/AdamsBridge_MLDSA.md
+++ b/docs/AdamsBridge_MLDSA.md
@@ -140,11 +140,13 @@ Valid values of MSG_STROBE include 4'b1111, 4'b0111, 4'b0011, 4'b0001, and 4'b00
 
 ### READY 
 
-​Indicates if the core is ready to process the inputs. 
+​Indicates if the core is ready to process the inputs.
 
-### ​VALID 
+After a completed operation, READY remains de-asserted (with VALID asserted) until firmware issues a ZEROIZE command. Firmware must zeroize between operations before issuing the next command.
 
-​Indicates if the process is computed and the output is valid.
+### ​VALID 
+
+​Indicates if the process is computed and the output is valid. VALID stays asserted until a ZEROIZE command (or reset) clears it.
 
 ### MSG_STREAM_READY
 
@@ -237,7 +239,7 @@ Output:
     sk_out
     pk
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0
 while read_data == 0:
     read_data = read(ADDR_STATUS)
@@ -249,7 +251,7 @@ write(ADDR_ENTROPY, entropy)
 // Trigger the core for performing Keygen
 write(ADDR_CTRL, KEYGEN_CMD)  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0
 while read_data == 0:
     read_data = read(ADDR_STATUS)
@@ -257,6 +259,13 @@ while read_data == 0:
 // Reading the outputs
 sk_out = read(ADDR_SK)
 pk = read(ADDR_PK)
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD)
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0
+while read_data == 0:
+    read_data = read(ADDR_STATUS)
 
 // Return the outputs
 return sk_out, pk
@@ -274,7 +283,7 @@ return sk_out, pk
 Output:
     signature  
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -289,7 +298,7 @@ write(ADDR_ENTROPY, entropy);
 // Trigger the core for performing Signing
 write(ADDR_CTRL, SIGN_CMD);  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -297,6 +306,14 @@ while (read_data == 0) {
 
 // Reading the outputs
 signature = read(ADDR_SIGNATURE);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output (signature)
 return signature;
@@ -313,7 +330,7 @@ Input:
 Output:
     verification_result   
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -327,7 +344,7 @@ write(ADDR_SIGNATURE, signature);
 // Trigger the core for performing Verifying
 write(ADDR_CTRL, VERIFY_CMD);  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -335,6 +352,14 @@ while (read_data == 0) {
 
 // Reading the outputs
 verification_result = read(ADDR_VERIFICATION_RESULT);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output (verification_result)
 return verification_result;
@@ -354,7 +379,7 @@ Input:
 Output:
     signature  
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -369,7 +394,7 @@ write(ADDR_ENTROPY, entropy);
 // Trigger the core for performing Keygen + Signing
 write(ADDR_CTRL, KEYGEN_SIGN_CMD);  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -377,6 +402,14 @@ while (read_data == 0) {
 
 // Reading the outputs
 signature = read(ADDR_SIGNATURE);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output (signature)
 return signature;
@@ -396,7 +429,7 @@ Input:
 Output:
     signature
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -412,7 +445,7 @@ write(ADDR_ENTROPY, entropy);
 // CTRL = SIGN_CMD | EXTERNAL_MU
 write(ADDR_CTRL, SIGN_CMD | EXTERNAL_MU);  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -420,6 +453,14 @@ while (read_data == 0) {
 
 // Reading the outputs
 signature = read(ADDR_SIGNATURE);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output (signature)
 return signature;
@@ -438,7 +479,7 @@ Input:
 Output:
     verification_result
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -453,7 +494,7 @@ write(ADDR_SIGNATURE, signature);
 // CTRL = VERIFY_CMD | EXTERNAL_MU
 write(ADDR_CTRL, VERIFY_CMD | EXTERNAL_MU);  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -461,6 +502,14 @@ while (read_data == 0) {
 
 // Reading the outputs
 verification_result = read(ADDR_VERIFICATION_RESULT);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output (verification_result)
 return verification_result;
@@ -480,7 +529,7 @@ Input:
 Output:
     signature
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -496,7 +545,7 @@ write(ADDR_ENTROPY, entropy);
 // CTRL = KEYGEN_SIGN_CMD | EXTERNAL_MU
 write(ADDR_CTRL, KEYGEN_SIGN_CMD | EXTERNAL_MU);  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -504,6 +553,14 @@ while (read_data == 0) {
 
 // Reading the outputs
 signature = read(ADDR_SIGNATURE);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output (signature)
 return signature;
@@ -525,7 +582,7 @@ Input:
 Output:
     signature
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -566,7 +623,7 @@ for (i = 0; i < msg_full_dwords; i++) {
 write(ADDR_MSG_STROBE, last_strobe);  // 0x0 if aligned, 0x1/0x3/0x7 if partial
 write(ADDR_MSG[0], last_dword);
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -574,6 +631,14 @@ while (read_data == 0) {
 
 // Reading the outputs
 signature = read(ADDR_SIGNATURE);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output (signature)
 return signature;
@@ -594,7 +659,7 @@ Input:
 Output:
     verification_result
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -628,7 +693,7 @@ for (i = 0; i < msg_full_dwords; i++) {
 write(ADDR_MSG_STROBE, last_strobe);
 write(ADDR_MSG[0], last_dword);
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -636,6 +701,14 @@ while (read_data == 0) {
 
 // Reading the outputs
 verification_result = read(ADDR_VERIFICATION_RESULT);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output (verification_result)
 return verification_result;
@@ -657,7 +730,7 @@ Input:
 Output:
     signature
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -692,7 +765,7 @@ for (i = 0; i < msg_full_dwords; i++) {
 write(ADDR_MSG_STROBE, last_strobe);
 write(ADDR_MSG[0], last_dword);
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -700,6 +773,14 @@ while (read_data == 0) {
 
 // Reading the outputs
 signature = read(ADDR_SIGNATURE);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output (signature)
 return signature;

--- a/docs/AdamsBridge_MLKEM.md
+++ b/docs/AdamsBridge_MLKEM.md
@@ -177,7 +177,7 @@ Output:
     encaps_key
     decaps_key
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0
 while read_data == 0:
     read_data = read(ADDR_STATUS)
@@ -190,7 +190,7 @@ write(ADDR_ENTROPY, entropy)
 // Trigger the core for performing Keygen
 write(ADDR_CTRL, KEYGEN_CMD)  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0
 while read_data == 0:
     read_data = read(ADDR_STATUS)
@@ -198,6 +198,13 @@ while read_data == 0:
 // Reading the outputs
 encaps_key = read(ADDR_EK)
 decaps_key = read(ADDR_DK)
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD)
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0
+while read_data == 0:
+    read_data = read(ADDR_STATUS)
 
 // Return the outputs
 return encaps_key, decaps_key
@@ -215,7 +222,7 @@ Output:
     shared_key
     ciphertext
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -229,7 +236,7 @@ write(ADDR_ENTROPY, entropy);
 // Trigger the core for performing Encapsulation
 write(ADDR_CTRL, ENCAPS_CMD);  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -238,6 +245,14 @@ while (read_data == 0) {
 // Reading the outputs
 shared_key = read(ADDR_SHAREDKEY);
 ciphertext = read(ADDR_CIPHERTEXT);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output
 return shared_key, ciphertext;
@@ -254,7 +269,7 @@ Input:
 Output:
     shared_key
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -268,7 +283,7 @@ write(ADDR_ENTROPY, entropy);
 // Trigger the core for performing decapsulation
 write(ADDR_CTRL, DECAPS_CMD);  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0;
 while (read_data == 0) {
     read_data = read(ADDR_STATUS);
@@ -276,6 +291,14 @@ while (read_data == 0) {
 
 // Reading the output
 shared_key = read(ADDR_SHAREDKEY);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the output
 return shared_key;
@@ -295,7 +318,7 @@ Input:
 Output:
     shared_key
 
-// Wait for the core to be ready (STATUS flag should be 2'b01 or 2'b11)
+// Wait for the core to be ready (STATUS flag should be 2'b01, i.e., READY=1, VALID=0)
 read_data = 0
 while read_data == 0:
     read_data = read(ADDR_STATUS)
@@ -309,13 +332,21 @@ write(ADDR_ENTROPY, entropy)
 // Trigger the core for performing Keygen + Decapsulation
 write(ADDR_CTRL, KEYGEN_DECAPS_CMD)  // (STATUS flag will be changed to 2'b00)
 
-// Wait for the core to be ready and valid (STATUS flag should be 2'b11)
+// Wait for the operation to complete (STATUS flag should be 2'b10, i.e., READY=0, VALID=1).
 read_data = 0
 while read_data == 0:
     read_data = read(ADDR_STATUS)
 
 // Reading the output
 shared_key = read(ADDR_SHAREDKEY);
+
+// Zeroize (mandatory after every completed operation)
+write(ADDR_CTRL, ZEROIZE_CMD);
+// Wait for the core to be ready again (STATUS flag should be 2'b01)
+read_data = 0;
+while (read_data == 0) {
+    read_data = read(ADDR_STATUS);
+}
 
 // Return the outputs
 return shared_key;


### PR DESCRIPTION
Fixes #276.

The per-algorithm flow docs told firmware to poll for STATUS = 2'b11 after a command, which can never occur: as of commit 49bcbaa ("mandate zeroize between all operations"), `abr_prog_cntr` parks at the operation's end state after completion, so `READY` stays low (with `VALID` high) until firmware issues a ZEROIZE. The HW spec already documents this policy (Zeroize section in `AdamsBridgeHardwareSpecification.md`); the MLDSA/MLKEM flow examples did not.

This PR updates `docs/AdamsBridge_MLDSA.md` and `docs/AdamsBridge_MLKEM.md`:
- Pre-command wait clarified as STATUS = 2'b01 (READY=1, VALID=0).
- Post-command wait clarified as STATUS = 2'b10 (READY=0, VALID=1) instead of the unreachable 2'b11.
- A ZEROIZE step + ready re-poll added before each `return` in every pseudocode flow (Keygen / Sign / Verify / Keygen+Sign and their External-Mu and Streaming-Msg variants; MLKEM Keygen / Encaps / Decaps / Keygen+Decaps).
- Clarifying notes added to the `READY` and `VALID` status-bit descriptions.

No RTL change.