### PR TITLE
Fix makehint boundary condition

### DIFF
--- a/docs/AdamsBridge_MLDSA.md
+++ b/docs/AdamsBridge_MLDSA.md
@@ -2548,6 +2548,8 @@ At the end of all polynomials, the hintsum is written to the register API to con
 
 It is possible that during the last cycle of the last polynomial, the index buffer contains \< 1 dword of index values to be written to the reg API. To accommodate this scenario, the controller flushes out the buffer at the end of the last polynomial and writes the remaining data to the register API.
 
+The flush is only applied after the final polynomial. Across intermediate polynomial boundaries, the packed hint indices remain contiguous in y\[ω-1:0\]; inserting padding at each polynomial boundary would break the cumulative hintsum byte ranges used by HintBitUnpack/sigDecode_h.
+
 ## W1Encode Architecture
 
 The signer’s commitment is shown by w, while this value needs to be decomposed into two shares to provide the required hint as a part of signature. The output of decompose is shown by (w1, w0) which presents the higher and lower parts of the given input. While w0 can be stored into the memory, the value of w1 is required to compute commitment hash using SHAKE256 operation. The following equation shows this operation:

--- a/src/makehint/rtl/hintgen.sv
+++ b/src/makehint/rtl/hintgen.sv
@@ -60,7 +60,7 @@ module hintgen
 
     always_comb begin
         r_lt_gamma2         = (r <= MLDSA_GAMMA2)   ? 1'b1 : 1'b0;
-        r_gt_q_minus_gamma2 = (r >= Q_MINUS_GAMMA2) ? 1'b1 : 1'b0;
+        r_gt_q_minus_gamma2 = (r > Q_MINUS_GAMMA2) ? 1'b1 : 1'b0;
         r_eq_q_minus_gamma2 = (r == Q_MINUS_GAMMA2) ? 1'b1 : 1'b0;
     end
 

--- a/src/makehint/rtl/makehint.sv
+++ b/src/makehint/rtl/makehint.sv
@@ -69,9 +69,9 @@ module makehint
     logic max_index_buffer_rd;
 
     //Sample buffer wires
-    //Flush buffer will perform last write of last polynomial irrespective of data_valid from sample buffer.
-    //This will take care of the case where at the end of index count, if buffer has < NUM_WR values, we still want to capture into reg API, padded with 0s
-    //For each poly_done, sample_buffer continues to capture values as they come in and this extra write is not required until the end
+    //Flush buffer only performs the final write after the last polynomial irrespective of data_valid from sample buffer.
+    //This handles the case where the encoded h stream ends with < NUM_WR indices and the final dword still needs to be committed to the reg API.
+    //Intermediate polynomials must not flush/pad the buffer because the encoded h indices are packed contiguously across polynomial boundaries.
     logic flush_buffer, flush_buffer_reg;
     logic sample_valid;
     logic [3:0][BUFFER_DATA_W-1:0] sample_data;
@@ -203,7 +203,7 @@ module makehint
 
     //Reg API
     //Write from sample buffer for each dword captured per polynomial.
-    //If last poly is done, flush buffer and write to reg API
+    //If the last poly is done, flush the final partial buffer contents and write them to the reg API
     //After that, write the max_index_buffer contents to reg API - using delayed poly_last as the wren in this case
     assign reg_wren = sample_valid | flush_buffer | max_index_buffer_rd;
     assign reg_wrdata = max_index_buffer_rd ? max_index_buffer_data : (sample_valid | flush_buffer) ? sample_data : '0;


### PR DESCRIPTION
## Summary

Fix the `makehint` hint boundary condition to match the ML-DSA/Dilithium reference behavior, and clarify that the residual hint-index buffer flush is intentionally performed only after the final polynomial.  Fixes: https://github.com/chipsalliance/adams-bridge/issues/95

## Problem

Two issues were reviewed in `makehint`:

1. **Hint boundary mismatch in `hintgen`**
   - The spec/reference behavior distinguishes:
     - `r <= GAMMA2`
     - `r > Q - GAMMA2`
     - `r == Q - GAMMA2` (special handling based on `z`)
   - RTL was using `r >= Q - GAMMA2`, which incorrectly merged the strict-greater-than and equality cases.

2. **Question around buffer flush timing**
   - The implementation only flushes the residual packed hint-index buffer after the final polynomial.
   - This initially looked inconsistent with the interpretation that flushing should happen at the end of every polynomial.

## Root cause / analysis

### 1. `hintgen` comparison bug
`src/makehint/rtl/hintgen.sv` used:

- `r <= GAMMA2`
- `r >= Q - GAMMA2`
- `r == Q - GAMMA2`

This is incorrect because the equality case must remain separate and be gated by the `z != 0` condition, matching both:
- `src/makehint/tb/makehint_ref.py`
- Dilithium reference `rounding.c`

### 2. Final-polynomial-only flush is intentional
The packed `h` encoding stores hint indices contiguously in `y[ω-1:0]`, while `y[ω+k-1:ω]` stores cumulative per-polynomial hint counts.

Because `sigdecode_h` reconstructs each polynomial’s hint slice using those cumulative counts, inserting padding at every polynomial boundary would create holes in the contiguous index stream and break decode semantics.

As a result, the residual buffer flush must happen only once, after the final polynomial.

## Changes

### RTL
- In `src/makehint/rtl/hintgen.sv`
  - Changed:
    - `r >= Q_MINUS_GAMMA2`
  - To:
    - `r > Q_MINUS_GAMMA2`

### Documentation / comments
- In `src/makehint/rtl/makehint.sv`
  - Clarified that buffer flushing is only for the final partial packed word after the last polynomial.
- In `docs/AdamsBridge_MLDSA.md`
  - Added clarification that intermediate polynomial boundaries must remain contiguous in `y[ω-1:0]`, so per-polynomial padding/flush is not valid.

## Validation

- Static file/error checks on edited files completed successfully.
- Reviewed RTL against:
  - `src/makehint/tb/makehint_ref.py`
  - Dilithium reference `rounding.c`
  - `sigdecode_h` packed-h decode behavior

## Impact

- Fixes the `makehint` boundary-condition mismatch for the `r == Q - GAMMA2` / `r > Q - GAMMA2` cases.
- Preserves correct contiguous packing of hint indices across polynomial boundaries.
- Makes the final-buffer-flush behavior explicit for future readers/reviewers.
